### PR TITLE
overflow: hidden na header__botom

### DIFF
--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -40,6 +40,7 @@
 
   .header__bottom {
     min-height: 447px;
+    overflow: hidden;
   }
 
   .header__title {


### PR DESCRIPTION
koła nie widać poza container na mobile